### PR TITLE
fix: Resolve complete CSRF validation failure

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -146,7 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('input[name="csrf_token"]').value
+                    'X-CSRFToken': document.querySelector('input[name="csrf_token"]').value
                 },
                 body: JSON.stringify({ name: name.trim(), content: content })
             });
@@ -329,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const cc = document.getElementById('cc').value.trim();
         const cco = document.getElementById('cco').value.trim();
         const message = document.getElementById('message').value.trim();
-        const attachmentFiles = attachmentInput.files;
+        const attachmentFiles = document.getElementById('attachment-input').files;
         const csrfToken = document.querySelector('input[name="csrf_token"]').value;
 
         if (!subject) {
@@ -375,14 +375,14 @@ document.addEventListener('DOMContentLoaded', () => {
             attachments.push(...await Promise.all(filePromises));
         }
 
-        const payload = { 
-            subject: subject, 
-            cc: cc, 
-            bcc: cco, 
-            message: message, 
-            attachments: attachments, 
+        const payload = {
+            subject: subject,
+            cc: cc,
+            bcc: cco,
+            message: message,
+            attachments: attachments,
             csvContent: selectedCsvContent,
-            manualEmails: emails 
+            manualEmails: emails
         };
 
         try {
@@ -391,7 +391,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-CSRF-Token': csrfToken
+                    // LINHA CORRIGIDA ABAIXO
+                    'X-CSRFToken': csrfToken
                 },
                 body: JSON.stringify(payload)
             });
@@ -408,7 +409,7 @@ document.addEventListener('DOMContentLoaded', () => {
             log(`Erro na conexão: ${error.message}`, 'error');
         } finally {
             button.disabled = false;
-            button.textContent = "ENVIAR SINAL";
+            button.textContent = "ENVIAR BROADCAST"; // Revertido para o texto original do botão
             progressBar.style.width = '0%';
             log("Processo concluído.");
         }


### PR DESCRIPTION
This commit fixes two bugs that together caused the "Send Broadcast" button to fail silently.

First, an incorrect conditional `{% if csrf_token %}` was removed from `app/templates/index.html`. This conditional prevented the CSRF hidden input from being rendered, which caused a JavaScript error when the form was submitted, stopping the request from ever being sent.

Second, the CSRF header sent in AJAX requests from `app/static/js/main.js` was changed from `X-CSRF-Token` to the correct `X-CSRFToken`, which is the default expected by Flask-WTF. This ensures that once the request is sent, it is not rejected by the server's CSRF protection.